### PR TITLE
Topic/use cython memory view

### DIFF
--- a/eigen/c_eigen.pxd
+++ b/eigen/c_eigen.pxd
@@ -58,6 +58,7 @@ cdef extern from "<Eigen/Dense>" namespace "Eigen":
     Matrix[T,nCol,nRow] transpose()
     void setZero()
     Matrix[T,nRow,nCol] Zero()
+    T* data()
 
   ctypedef Matrix[double, two, one] Vector2d
   ctypedef Matrix[double, three, one] Vector3d

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ except ImportError:
 from Cython.Build import cythonize
 import os
 import subprocess
+import numpy
 
 win32_build = os.name == 'nt'
 
@@ -109,7 +110,7 @@ def GenExtension(name, pkg, ):
   pyx_src = pyx_src + '.pyx'
   ext_src = pyx_src
   if pkg.found:
-    return Extension(name, [ext_src], extra_compile_args = pkg.compile_args, include_dirs = pkg.include_dirs, library_dirs = pkg.library_dirs, libraries = pkg.libraries)
+    return Extension(name, [ext_src], extra_compile_args = pkg.compile_args, include_dirs = pkg.include_dirs + [numpy.get_include()], library_dirs = pkg.library_dirs, libraries = pkg.libraries)
   else:
     print("Failed to find {}".format(pkg.name))
     return None

--- a/utils/generate_eigen_pyx.py
+++ b/utils/generate_eigen_pyx.py
@@ -125,6 +125,9 @@ def generateBaseBinding(className, type, nRow, nCol):
     cdef MatrixXd ret = MatrixXd(p, q)
     ret.impl = <c_eigen.MatrixXd>(self.impl.block(i,j,p,q))
     return ret
+  def __array__(self):
+    A = numpy.asarray(<numpy.double_t[:self.impl.cols(), :self.impl.rows()]> self.impl.data()).T
+    return A
   def block(self, int i, int j, int p, int q):
     if q == 1:
       return self.__vblock(i,j,p,q)
@@ -504,11 +507,6 @@ def generateVectorBinding(className, type, nRow, nCol):
             raise IndexError("Trying to set an element with a sequence")
       else:
         self.impl[idx] = value
-  def __array__(self):
-    A = numpy.zeros((self.impl.rows(), 1))
-    for i in range(self.impl.rows()):
-      A[i] = self.impl[i]
-    return A
   def __mul__(self, other):
     if isinstance(self, {0}):
       if isinstance(other, MatrixXd):
@@ -657,7 +655,8 @@ cimport c_eigen_private
       fd.write(effd.read())
   with open("{}/eigen.pxd".format(out_path), 'w') as fd:
     fd.write("# This file was automatically generated, do not modify it\n")
-    fd.write("import numpy\n")
+    fd.write("cimport numpy\n")
+    fd.write("from cython.view cimport array as cvarray\n")
     fd.write("from libcpp.vector cimport vector\n")
     fd.write("cimport c_eigen\n")
     fd.write(generateDeclaration("MatrixXd"))


### PR DESCRIPTION
This avoids needlessly copying the entries one by one when converting an Eigen type to a Numpy type. The copy is done at once when calling `np.asarray`. The opposite conversion is not yet ready, but it will be harder to implement as all functions can only take an `Eigen::Type` and not an `Eigen::Ref<Eigen::Type>` meaning that `Map<M>` is not interchangeable with `M`.