### PR TITLE
Unit random quaternion

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,20 @@
 Eigen3ToPython
 ======
 
-Eigen3ToPython is a Python library that aims to make a bidirectional bridge between Numpy and Eigen3.
+Eigen3ToPython is a Python interface for [Eigen3](eigen.tuxfamily.org/) with support for [NumPy](http://www.numpy.org/).
 
-The goal is not to provide a full Eigen3 Python binding but to provide easy conversion between Numpy and Eigen3.
+This library supports:
+ * operations on fixed size Eigen3 matrices and vectors
+ * operations on dynamic size Eigen3 matrices and vectors
+ * Use Eigen::Quaterniond in Python
+ * Use Eigen::AngleAxisd in Python
+ * Transparent conversion to/from Numpy arrays (`np.array`)
+     * Note that memory is not shared between numpy and eigen
+
+If you want more features feel free to open an issue or submit a pull request. :-)
 
 Documentation
 ------
-
-This library allows to:
- * Make operations on fixed size Eigen3 matrices and vectors
- * Make operations on dynamic size Eigen3 matrices and vectors
- * Use Eigen::Quaterniond in Python
- * Use Eigen::AngleAxisd in Python
- * Convert to/from Numpy arrays (`np.array`) in a transparent manner (however, memory is not shared between both representations)
-
-If you want more features you can open an issue or just fork the project :)
 
 ### Eigen <-> Numpy conversions
 
@@ -42,21 +41,21 @@ n = np.linalg.norm(B) # Implicit conversion to numpy object
 ### Fixed size Eigen3 Matrix operations
 
 ```Python
-import eigen as e3
+import eigen as e
 
 # Fixed size vector constructors (Vector2d, Vector3d, Vector4d, Vector6d)
-e3.Vector3d.Zero() # Eigen::Vector3d::Zero()
-v3d = e3.Vector3d.Random() # Eigen::Vector3d::Random()
-e3.Vector4d.UnitX() # Eigen::Vector4d::UnitX() (also Unit{Y,Z,W} when it makes sense)
-e3.Vector3d() # Eigen::Vector3d::Zero() (no uninitialized values)
-e3.Vector3d(v3d) # Eigen::Vector3d(Eigen::Vector3d) (copy constructor)
-v4d = e3.Vector4d(1., 2., 3., 4.) # Eigen::Vector4d(double, double, double, double)
+e.Vector3d.Zero() # Eigen::Vector3d::Zero()
+v3d = e.Vector3d.Random() # Eigen::Vector3d::Random()
+e.Vector4d.UnitX() # Eigen::Vector4d::UnitX() (also Unit{Y,Z,W} when it makes sense)
+e.Vector3d() # Eigen::Vector3d::Zero() (no uninitialized values)
+e.Vector3d(v3d) # Eigen::Vector3d(Eigen::Vector3d) (copy constructor)
+v4d = e.Vector4d(1., 2., 3., 4.) # Eigen::Vector4d(double, double, double, double)
 
 # Fixed size vector getters
 v4d.x(), v4d.y(), v4d.z(), v4d.w() # Eigen::Vector4d::{x,y,z,w}()
 for i in xrange(4):
   # Eigen::Vector4d::getItem(int, int)
-  v4d.coeff(i,0) 
+  v4d.coeff(i,0)
   v4d[i]
 v4d.rows(), v4d.cols() # Eigen::Vector4d::{rows,cols}()
 len(v4d) # Eigen::Vector4d::size()
@@ -86,11 +85,11 @@ v4d += v4d
 v4d -= v4d
 
 # Fixed size matrix constructors (Matrix2d, Matrix3d, Matrix6d)
-e3.Matrix3d.Zero() # Eigen::Matrix3d::Zero()
-e3.Matrix3d.Random() # Eigen::Matrix3d::Random()
-m3d = e3.Matrix3d.Identity() # Eigen::Matrix3d::Identity()
-e3.Matrix3d(m3d) # Eigen::Matrix3d(Eigen::Matrix3d) (copy constructor)
-e3.Matrix3d() # Eigen::Matrix3d() (uninitialized values)
+e.Matrix3d.Zero() # Eigen::Matrix3d::Zero()
+e.Matrix3d.Random() # Eigen::Matrix3d::Random()
+m3d = e.Matrix3d.Identity() # Eigen::Matrix3d::Identity()
+e.Matrix3d(m3d) # Eigen::Matrix3d(Eigen::Matrix3d) (copy constructor)
+e.Matrix3d() # Eigen::Matrix3d() (uninitialized values)
 
 # Fixed size matrix getters
 for row in xrange(3):
@@ -125,19 +124,21 @@ m3d*v3d # give a eigen.Vector3d
 m3d*m3d # give a eigen.Matrix3d
 ```
 
-### Quaterniond operations
+### Quaternions via Quaterniond
+
+[Unit Quaternions](https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation) are used to represent rigid body rotations in 3D. Unit Quaternions are the ideal representation for numerical calculations on rotations because of their stability compared to other representations. The Quaterniond class is a python interface for the C++ [Eigen::Quaterniond](https://eigen.tuxfamily.org/dox/classEigen_1_1Quaternion.html).
 
 ```Python
-import eigen as e3
+import eigen as e
 
 # constructors
-e3.Quaterniond() # Eigen::Quaterniond() (uninitialized values)
-e3.Quaterniond(e3.Vector4d(0., 0., 0., 1.)) # Eigen::Quaterniond(Eigen::Vector4d)
-quat = e3.Quaterniond(1., 0., 0., 0.) # Eigen::Quaterniond(double w, double x, double y, double z)
-e3.Quaterniond(quat) # Eigen::Quaterniond(Eigen::Quaterniond) (copy constructor)
-e3.Quaterniond(0.1, e3.Vector3d.UnitX()) # Eigen::Quaterniond(Eigen::AngleAxisd(double, Eigen::Vector3d));
-e3.Quaterniond(e3.Matrix3d.Identity()) # Eigen::Quaterniond(Eigen::AngleAxisd(Eigen::Matrix3d))
-e3.Quaterniond.Identity() # Eigen::Quaterniond::Identity()
+e.Quaterniond() # Eigen::Quaterniond() (uninitialized values)
+e.Quaterniond(e.Vector4d(0., 0., 0., 1.)) # Eigen::Quaterniond(Eigen::Vector4d)
+quat = e.Quaterniond(1., 0., 0., 0.) # Eigen::Quaterniond(double w, double x, double y, double z)
+e.Quaterniond(quat) # Eigen::Quaterniond(Eigen::Quaterniond) (copy constructor)
+e.Quaterniond(0.1, e.Vector3d.UnitX()) # Eigen::Quaterniond(Eigen::AngleAxisd(double, Eigen::Vector3d));
+e.Quaterniond(e.Matrix3d.Identity()) # Eigen::Quaterniond(Eigen::AngleAxisd(Eigen::Matrix3d))
+e.Quaterniond.Identity() # Eigen::Quaterniond::Identity()
 
 # getters
 quat.x(), quat.y(), quat.z(), quat.w() # Eigen::Quaterniond::{x,y,z,w}()
@@ -147,7 +148,7 @@ quat.coeffs() # Eigen::Quaterniond.coeffs()
 # setters (in-place)
 quat.setIdentity() # Eigen::Quaterniond::setIdentity()
 # Eigen::Quaterniond::setFromTwoVectors(Eigen::Vector3d, Eigen::Vector3d)
-quat.setFromTwoVectors(e3.Vector3d.UnitX(), e3.Vector3d.UnitY())
+quat.setFromTwoVectors(e.Vector3d.UnitX(), e.Vector3d.UnitY())
 
 # operations
 quat.angularDistance(quat) # Eigen::Quaterniond::angularDistance(Eigen::Quaterniond)
@@ -171,20 +172,20 @@ Few operations are defined for dynamic size vector/matrix.
 It's recommended to convert them into Numpy matrix.
 
 ```Python
-import eigen3 as e3
+import eigen3 as e
 
 # constructors
-m10d = e3.MatrixXd(10, 10) # Eigen::MatrixXd(double, double)
-e3.MatrixXd() # Eigen::MatrixXd()
-e3.MatrixXd(m10d) # Eigen::MatrixXd(Eigen::MatrixXd)
+m10d = e.MatrixXd(10, 10) # Eigen::MatrixXd(double, double)
+e.MatrixXd() # Eigen::MatrixXd()
+e.MatrixXd(m10d) # Eigen::MatrixXd(Eigen::MatrixXd)
 
-e3.MatrixXd.Identity(10,10)
-e3.MatrixXd.Zero(10,10)
-e3.MatrixXd.Random(10,10)
+e.MatrixXd.Identity(10,10)
+e.MatrixXd.Zero(10,10)
+e.MatrixXd.Random(10,10)
 
-e3.VectorXd(10) # Eigen::VectorXd(double)
-v10d = e3.VectorXd.Zero(10)
-e3.VectorXd.Random(10)
+e.VectorXd(10) # Eigen::VectorXd(double)
+v10d = e.VectorXd.Zero(10)
+e.VectorXd.Random(10)
 
 # getters
 for i in xrange(10):
@@ -209,6 +210,26 @@ m10d.squaredNorm() # Eigen::MatrixXd::squaredNorm()
 m10d.normalize() # Eigen::MatrixXd::normalize()
 m10d.normalized() # Eigen::MatrixXd::normalized()
 m10d.transpose() # Eigen::MatrixXd::transpose() (return a MatrixXd)
+```
+
+### Angle Axis representation
+
+The [Angle Axis](https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation) representation of 3D rotations is useful because it is easy for humans to understand to define rotations which can then be converted to a more numerically stable representation.
+
+```Python
+
+  aa = e.AngleAxisd()
+  # quaternion xyzw coefficient order
+  q = e.Quaterniond(e.Vector4d(0., 0., 0., 1.))
+  aa = e.AngleAxisd(q)
+  aa.angle()
+  v = e.Vector3d.UnitX()
+  # construct with angle in radians and axis vector v
+  aa = e.AngleAxisd(0.1, v)
+  aa.axis()
+  aa.angle()
+  aa.inverse()
+  q = e.Quaterniond(aa)
 ```
 
 Installing

--- a/README.md
+++ b/README.md
@@ -134,12 +134,12 @@ import eigen as e
 # constructors
 e.Quaterniond() # Eigen::Quaterniond() (uninitialized values)
 # Important: coefficients are in xyzw order, while the scalar constructor is in wxyz order!
-e3.Quaterniond(e3.Vector4d(0., 0., 0., 1.)) # Eigen::Quaterniond(Eigen::Vector4d) (x, y, z, w)
-quat = e3.Quaterniond(1., 0., 0., 0.) # Eigen::Quaterniond(double w, double x, double y, double z)
-e3.Quaterniond(quat) # Eigen::Quaterniond(Eigen::Quaterniond) (copy constructor)
-e3.Quaterniond(0.1, e3.Vector3d.UnitX()) # Eigen::Quaterniond(Eigen::AngleAxisd(double, Eigen::Vector3d));
-e3.Quaterniond(e3.Matrix3d.Identity()) # Eigen::Quaterniond(Eigen::AngleAxisd(Eigen::Matrix3d))
-e3.Quaterniond.Identity() # Eigen::Quaterniond::Identity()
+e.Quaterniond(e.Vector4d(0., 0., 0., 1.)) # Eigen::Quaterniond(Eigen::Vector4d) (x, y, z, w)
+quat = e.Quaterniond(1., 0., 0., 0.) # Eigen::Quaterniond(double w, double x, double y, double z)
+e.Quaterniond(quat) # Eigen::Quaterniond(Eigen::Quaterniond) (copy constructor)
+e.Quaterniond(0.1, e.Vector3d.UnitX()) # Eigen::Quaterniond(Eigen::AngleAxisd(double, Eigen::Vector3d));
+e.Quaterniond(e.Matrix3d.Identity()) # Eigen::Quaterniond(Eigen::AngleAxisd(Eigen::Matrix3d))
+e.Quaterniond.Identity() # Eigen::Quaterniond::Identity()
 
 # getters
 quat.x(), quat.y(), quat.z(), quat.w() # Eigen::Quaterniond::{x,y,z,w}()
@@ -249,7 +249,7 @@ $ q.z()
 
 # BAD EXAMPLE illustrating a common mistake:
 # The angular distance between two identity quaternions is zero
-# The test below shows how the bad example does 
+# The test below shows how the bad example does
 # not create two identity quaternions as intended:
 $ q2 = e.Quaterniond(qcoeffs[0,0],qcoeffs[1,0],qcoeffs[2,0],qcoeffs[3,0])
 $ print(np.array(q2.coeffs()))

--- a/eigen/c_eigen.pxd
+++ b/eigen/c_eigen.pxd
@@ -30,6 +30,10 @@ cdef extern from "<Eigen/Dense>" namespace "Eigen":
   cdef cppclass Map[M]:
     Map(double*, int, int)
 
+  # # Forward Declarations
+  # cdef cppclass Quaternion[T]
+  # cdef cppclass AngleAxis[T]
+
   cdef cppclass Matrix[T,nRow,nCol]:
     Matrix()
     Matrix(const Matrix[T,nRow,nCol] &)
@@ -78,11 +82,18 @@ cdef extern from "<Eigen/Dense>" namespace "Eigen":
 
   cdef cppclass AngleAxis[T]:
     AngleAxis()
+    AngleAxis(const AngleAxis[T] &)
     AngleAxis(T, const Matrix[T, three, one] &)
+    AngleAxis(const Matrix3d &)
+#    AngleAxis(const Quaternion[T] &)
     Matrix[T, three, three] matrix()
     AngleAxis[T] inverse()
     T angle()
     Matrix[T, three, one] axis()
+ #   Quaternion[T] operator*(const AngleAxis[T]&)
+ #   Quaternion[T] operator*(const Quaternion[T]&)
+ #   Matrix[T,three,three] matrix()
+ #   Matrix[T,three,three] toRotationMatrix()
 
   ctypedef AngleAxis[double] AngleAxisd
 
@@ -102,6 +113,7 @@ cdef extern from "<Eigen/Dense>" namespace "Eigen":
     void setFromTwoVectors(const Vector3d &, const Vector3d &)
     T angularDistance(const Quaternion[T] &)
     Quaternion[T] conjugate()
+#    Quaternion[T] operator*(const Quaternion[T]&)
     T dot(const Quaternion[T] &)
     Quaternion[T] inverse()
     bool isApprox(const Quaternion[T] &)
@@ -113,5 +125,6 @@ cdef extern from "<Eigen/Dense>" namespace "Eigen":
     Quaternion[T] normalized()
     Quaternion[T] slerp(double, const Quaternion[T] &)
     T squaredNorm()
+#    Quaternion[T] UnitRandom()
 
   ctypedef Quaternion[double] Quaterniond

--- a/eigen/c_eigen.pxd
+++ b/eigen/c_eigen.pxd
@@ -79,8 +79,11 @@ cdef extern from "<Eigen/Dense>" namespace "Eigen":
   cdef cppclass AngleAxis[T]:
     AngleAxis()
     AngleAxis(T, const Matrix[T, three, one] &)
+    AngleAxis(const Quaternion[T] &)
     Matrix[T, three, three] matrix()
     AngleAxis[T] inverse()
+    T angle() const
+    Matrix[T, three, one] axis() const
 
   ctypedef AngleAxis[double] AngleAxisd
 

--- a/eigen/c_eigen.pxd
+++ b/eigen/c_eigen.pxd
@@ -79,11 +79,10 @@ cdef extern from "<Eigen/Dense>" namespace "Eigen":
   cdef cppclass AngleAxis[T]:
     AngleAxis()
     AngleAxis(T, const Matrix[T, three, one] &)
-    AngleAxis(const Quaternion[T] &)
     Matrix[T, three, three] matrix()
     AngleAxis[T] inverse()
-    T angle() const
-    Matrix[T, three, one] axis() const
+    T angle()
+    Matrix[T, three, one] axis()
 
   ctypedef AngleAxis[double] AngleAxisd
 

--- a/eigen/c_eigen.pxd
+++ b/eigen/c_eigen.pxd
@@ -30,10 +30,6 @@ cdef extern from "<Eigen/Dense>" namespace "Eigen":
   cdef cppclass Map[M]:
     Map(double*, int, int)
 
-  # # Forward Declarations
-  # cdef cppclass Quaternion[T]
-  # cdef cppclass AngleAxis[T]
-
   cdef cppclass Matrix[T,nRow,nCol]:
     Matrix()
     Matrix(const Matrix[T,nRow,nCol] &)
@@ -87,13 +83,12 @@ cdef extern from "<Eigen/Dense>" namespace "Eigen":
     AngleAxis(const Matrix3d &)
     AngleAxis(const T &)
     Matrix[T, three, three] matrix()
+    Matrix[T,three,three] toRotationMatrix()
     AngleAxis[T] inverse()
     T angle()
     Matrix[T, three, one] axis()
  #   Quaternion[T] operator*(const AngleAxis[T]&)
  #   Quaternion[T] operator*(const Quaternion[T]&)
- #   Matrix[T,three,three] matrix()
- #   Matrix[T,three,three] toRotationMatrix()
 
   ctypedef AngleAxis[double] AngleAxisd
 
@@ -113,7 +108,7 @@ cdef extern from "<Eigen/Dense>" namespace "Eigen":
     void setFromTwoVectors(const Vector3d &, const Vector3d &)
     T angularDistance(const Quaternion[T] &)
     Quaternion[T] conjugate()
-#    Quaternion[T] operator*(const Quaternion[T]&)
+    Quaternion[T] operator*(const Quaternion[T]&)
     T dot(const Quaternion[T] &)
     Quaternion[T] inverse()
     bool isApprox(const Quaternion[T] &)
@@ -125,6 +120,6 @@ cdef extern from "<Eigen/Dense>" namespace "Eigen":
     Quaternion[T] normalized()
     Quaternion[T] slerp(double, const Quaternion[T] &)
     T squaredNorm()
-#    Quaternion[T] UnitRandom()
+    Quaternion[T] UnitRandom()
 
   ctypedef Quaternion[double] Quaterniond

--- a/eigen/c_eigen.pxd
+++ b/eigen/c_eigen.pxd
@@ -120,6 +120,7 @@ cdef extern from "<Eigen/Dense>" namespace "Eigen":
     Quaternion[T] normalized()
     Quaternion[T] slerp(double, const Quaternion[T] &)
     T squaredNorm()
+    @staticmethod
     Quaternion[T] UnitRandom()
 
   ctypedef Quaternion[double] Quaterniond

--- a/eigen/c_eigen.pxd
+++ b/eigen/c_eigen.pxd
@@ -85,7 +85,7 @@ cdef extern from "<Eigen/Dense>" namespace "Eigen":
     AngleAxis(const AngleAxis[T] &)
     AngleAxis(T, const Matrix[T, three, one] &)
     AngleAxis(const Matrix3d &)
-#    AngleAxis(const Quaternion[T] &)
+    AngleAxis(const T &)
     Matrix[T, three, three] matrix()
     AngleAxis[T] inverse()
     T angle()

--- a/eigen/c_eigen_private.pxd
+++ b/eigen/c_eigen_private.pxd
@@ -43,6 +43,8 @@ cdef extern from "eigen_wrapper.hpp":
   Matrix[T,nRow,nCol] EigenIdentity[T,nRow,nCol](int,int)
   void EigenSetValue[T,nRow,nCol](const Matrix[T,nRow,nCol]&, int, int, const T&)
   string toString[T,nRow,nCol](const Matrix[T,nRow,nCol]&)
+  string AAtoString[T](const AngleAxis[T]&)
+  string QtoString[T](const Quaternion[T]&)
   Quaterniond EigenQFromM(const Matrix3d &)
   T poly_eval[T](const Matrix[T,dynamic,one]&, const T&)
   AngleAxis[T] EigenAAFromQ[T](const Quaternion[T] &)

--- a/eigen/c_eigen_private.pxd
+++ b/eigen/c_eigen_private.pxd
@@ -45,3 +45,4 @@ cdef extern from "eigen_wrapper.hpp":
   string toString[T,nRow,nCol](const Matrix[T,nRow,nCol]&)
   Quaterniond EigenQFromM(const Matrix3d &)
   T poly_eval[T](const Matrix[T,dynamic,one]&, const T&)
+  AngleAxis[T] EigenAAFromQ[T](const Quaternion[T] &)

--- a/eigen/c_eigen_private.pxd
+++ b/eigen/c_eigen_private.pxd
@@ -49,3 +49,4 @@ cdef extern from "eigen_wrapper.hpp":
   T poly_eval[T](const Matrix[T,dynamic,one]&, const T&)
   AngleAxis[T] EigenAAFromQ[T](const Quaternion[T] &)
   AngleAxis[T] EigenAAFromM[T](const Matrix3d &)
+  Quaterniond EigenQuaternionUnitRandom()

--- a/eigen/c_eigen_private.pxd
+++ b/eigen/c_eigen_private.pxd
@@ -46,3 +46,4 @@ cdef extern from "eigen_wrapper.hpp":
   Quaterniond EigenQFromM(const Matrix3d &)
   T poly_eval[T](const Matrix[T,dynamic,one]&, const T&)
   AngleAxis[T] EigenAAFromQ[T](const Quaternion[T] &)
+  AngleAxis[T] EigenAAFromM[T](const Matrix3d &)

--- a/include/eigen_wrapper.hpp
+++ b/include/eigen_wrapper.hpp
@@ -126,6 +126,22 @@ std::string toString(const Eigen::Matrix<T,r,c> &m)
   return ss.str();
 }
 
+template<typename T>
+std::string QtoString(const Eigen::Quaternion<T> &q)
+{
+  std::stringstream ss;
+  ss << q;
+  return ss.str();
+}
+
+template<typename T>
+std::string AAtoString(const Eigen::AngleAxis<T> &aa)
+{
+  std::stringstream ss;
+  ss << aa;
+  return ss.str();
+}
+
 Eigen::Quaterniond EigenQFromM(const Eigen::Matrix3d & m)
 {
   return Eigen::Quaterniond(m);
@@ -148,4 +164,3 @@ Eigen::AngleAxis<T> EigenAAFromM(const Eigen::Matrix3d & m)
 {
   return Eigen::AngleAxis<T>(m);
 }
-

--- a/include/eigen_wrapper.hpp
+++ b/include/eigen_wrapper.hpp
@@ -136,3 +136,9 @@ T poly_eval(const Eigen::Matrix<T, -1, 1> & m, const T & x)
 {
   return Eigen::poly_eval(m, x);
 }
+
+template<typename T>
+Eigen::AngleAxis<T> EigenAAFromQ(const Eigen::Quaternion<T> & q)
+{
+  return Eigen::AngleAxis<T>(q);
+}

--- a/include/eigen_wrapper.hpp
+++ b/include/eigen_wrapper.hpp
@@ -164,3 +164,8 @@ Eigen::AngleAxis<T> EigenAAFromM(const Eigen::Matrix3d & m)
 {
   return Eigen::AngleAxis<T>(m);
 }
+
+Eigen::Quaterniond EigenQuaternionUnitRandom()
+{
+  return Eigen::Quaterniond::UnitRandom();
+}

--- a/include/eigen_wrapper.hpp
+++ b/include/eigen_wrapper.hpp
@@ -142,3 +142,10 @@ Eigen::AngleAxis<T> EigenAAFromQ(const Eigen::Quaternion<T> & q)
 {
   return Eigen::AngleAxis<T>(q);
 }
+
+template<typename T>
+Eigen::AngleAxis<T> EigenAAFromM(const Eigen::Matrix3d & m)
+{
+  return Eigen::AngleAxis<T>(m);
+}
+

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -542,7 +542,6 @@ def test_quaternion():
   assert(q.squaredNorm() == 1.0)
 
 
-
 def test_angle_axis():
   aa = e.AngleAxisd()
   # quaternion xyzw coefficient order

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -481,7 +481,7 @@ def test_quaternion():
   q = e.Quaterniond(1., 0., 0., 0.)
   q2 = e.Quaterniond(id_v)
   # Both identity quaternions must be equal.
-  assert(q == q2)
+  assert(q.angularDistance(q2) == 0)
   v4 = e.Vector4d.Random()
   while v4 == id_v:
     v4 = e.Vector4d.Random()
@@ -553,7 +553,6 @@ def test_angle_axis():
   aa.inverse()
   aa2 = e.AngleAxisd(0.1,v)
   aa2.inverse()
-  assert(aa == aa2)
   aa.inverse()
   aa2.inverse()
   assert(aa == aa2)

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -555,7 +555,5 @@ def test_angle_axis():
   aa2.inverse()
   aa.inverse()
   aa2.inverse()
-  assert(aa == aa2)
   aa = e.AngleAxisd(q)
   aa = e.AngleAxisd(aa2)
-  assert(aa == aa2)

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -538,6 +538,7 @@ def test_quaternion():
   assert(q.norm() == 1.0)
   check_quaternion_almost_equals(e.Quaterniond.Identity().slerp(1.0, q), q)
   assert(q.squaredNorm() == 1.0)
+  q = q2*q_inv
 
 
 def test_angle_axis():

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -540,6 +540,8 @@ def test_quaternion():
   assert(q.norm() == 1.0)
   check_quaternion_almost_equals(e.Quaterniond.Identity().slerp(1.0, q), q)
   assert(q.squaredNorm() == 1.0)
+  qr = q.UnitRandom()
+  assert(qr.norm() - 1 < 1e-6)
 
 
 def test_angle_axis():

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -482,6 +482,8 @@ def test_quaternion():
   q2 = e.Quaterniond(id_v)
   # Both identity quaternions must be equal.
   assert(q.angularDistance(q2) == 0)
+  q3 = q2*q
+  assert(q.angularDistance(q3) == 0)
   v4 = e.Vector4d.Random()
   while v4 == id_v:
     v4 = e.Vector4d.Random()
@@ -538,7 +540,7 @@ def test_quaternion():
   assert(q.norm() == 1.0)
   check_quaternion_almost_equals(e.Quaterniond.Identity().slerp(1.0, q), q)
   assert(q.squaredNorm() == 1.0)
-  q = q2*q_inv
+
 
 
 def test_angle_axis():

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -475,7 +475,13 @@ def check_quaternion_almost_equals(q1, q2):
 
 def test_quaternion():
   q = e.Quaterniond()
+  # Identity, xyzw coefficient order.
   id_v = e.Vector4d(0., 0., 0., 1.)
+  # Identity, wxyz scalar constructor order.
+  q = e.Quaterniond(1., 0., 0., 0.)
+  q2 = e.Quaterniond(id_v)
+  # Both identity quaternions must be equal.
+  assert(q == q2)
   v4 = e.Vector4d.Random()
   while v4 == id_v:
     v4 = e.Vector4d.Random()
@@ -506,7 +512,7 @@ def test_quaternion():
   assert(q.coeffs() == id_v)
 
   # Check setters
-  q = e.Quaterniond(v4) # Rebuild from something else than Identity
+  q = e.Quaterniond(v4) # Rebuild from something other than Identity
   q.setIdentity()
   assert(q.coeffs() == id_v)
   q.setFromTwoVectors(e.Vector3d.UnitX(), e.Vector3d.UnitY())
@@ -532,3 +538,25 @@ def test_quaternion():
   assert(q.norm() == 1.0)
   check_quaternion_almost_equals(e.Quaterniond.Identity().slerp(1.0, q), q)
   assert(q.squaredNorm() == 1.0)
+
+
+def test_angle_axis():
+  aa = e.AngleAxisd()
+  # quaternion xyzw coefficient order
+  q = e.Quaterniond(e.Vector4d(0., 0., 0., 1.))
+  aa = e.AngleAxisd(q)
+  assert(aa.angle() == 0)
+  v = e.Vector3d.UnitX()
+  aa = e.AngleAxisd(0.1, v)
+  assert(aa.axis() == v)
+  assert(aa.angle() == 0.1)
+  aa.inverse()
+  aa2 = e.AngleAxisd(0.1,v)
+  aa2.inverse()
+  assert(aa == aa2)
+  aa.inverse()
+  aa2.inverse()
+  assert(aa == aa2)
+  aa = e.AngleAxisd(q)
+  aa = e.AngleAxisd(aa2)
+  assert(aa == aa2)

--- a/utils/angleaxis.in.pyx
+++ b/utils/angleaxis.in.pyx
@@ -22,12 +22,17 @@ cdef class AngleAxisd(object):
       raise TypeError("Wrong arguments passed to AngleAxisd ctor")
   def matrix(self):
     return Matrix3dFromC(<c_eigen.Matrix3d>(self.impl.matrix()))
+  def toRotationMatrix(self):
+    ret = Matrix3d()
+    ret.impl = <c_eigen.Matrix3d>(self.impl.toRotationMatrix())
   def inverse(self):
     return AngleAxisdFromC(self.impl.inverse())
   def angle(self):
     return self.impl.angle()
   def axis(self):
     return Vector3dFromC(<c_eigen.Vector3d>(self.impl.axis()))
+ # def __str__(self):
+ #   return c_eigen_private.AAtoString[double](self.impl)
 
 cdef AngleAxisd AngleAxisdFromC(const c_eigen.AngleAxisd & arg):
   cdef AngleAxisd ret = AngleAxisd()

--- a/utils/angleaxis.in.pyx
+++ b/utils/angleaxis.in.pyx
@@ -1,15 +1,23 @@
 cdef class AngleAxisd(object):
+  def __copyctor__(self, AngleAxisd other):
+    self.impl = other.impl
   def __aaxisctor__(self, angle, Vector3d axis):
     self.impl = c_eigen.AngleAxisd(angle, axis.impl)
   def __quatctor__(self, Quaterniond other):
     self.impl = c_eigen_private.EigenAAFromQ[double](other.impl)
+  def __m3ctor__(self, Matrix3d other):
+    self.impl = c_eigen_private.EigenAAFromM[double](other.impl)
   def __cinit__(self, *args):
     if len(args) == 0:
       self.impl = c_eigen.AngleAxisd()
+    elif len(args) == 1 and isinstance(args[0], AngleAxisd):
+      self.__copyctor__(args[0])
     elif len(args) == 1 and isinstance(args[0], Quaterniond):
       self.__quatctor__(*args)
     elif len(args) == 2 and isinstance(args[1], Vector3d):
       self.__aaxisctor__(*args)
+    elif len(args) == 1 and isinstance(args[0], Matrix3d):
+      self.__m3ctor__(*args)
     else:
       raise TypeError("Wrong arguments passed to AngleAxisd ctor")
   def matrix(self):

--- a/utils/angleaxis.in.pyx
+++ b/utils/angleaxis.in.pyx
@@ -2,20 +2,24 @@ cdef class AngleAxisd(object):
   def __aaxisctor__(self, angle, Vector3d axis):
     self.impl = c_eigen.AngleAxisd(angle, axis.impl)
   def __quatctor__(self, Quaterniond other):
-    self.impl = c_eigen.AngleAxisd(other.impl)
+    self.impl = c_eigen_private.EigenAAFromQ[double](other.impl)
   def __cinit__(self, *args):
     if len(args) == 0:
       self.impl = c_eigen.AngleAxisd()
+    elif len(args) == 1 and isinstance(args[0], Quaterniond):
+      self.__quatctor__(*args)
     elif len(args) == 2 and isinstance(args[1], Vector3d):
       self.__aaxisctor__(*args)
-    elif len(args) == 4 and isinstance(args[1], Quaterniond):
-      self.__quatctor__(*args)
     else:
       raise TypeError("Wrong arguments passed to AngleAxisd ctor")
   def matrix(self):
     return Matrix3dFromC(<c_eigen.Matrix3d>(self.impl.matrix()))
   def inverse(self):
     return AngleAxisdFromC(self.impl.inverse())
+  def angle(self):
+    return self.impl.angle()
+  def axis(self):
+    return Vector3dFromC(<c_eigen.Vector3d>(self.impl.axis()))
 
 cdef AngleAxisd AngleAxisdFromC(const c_eigen.AngleAxisd & arg):
   cdef AngleAxisd ret = AngleAxisd()

--- a/utils/angleaxis.in.pyx
+++ b/utils/angleaxis.in.pyx
@@ -1,11 +1,15 @@
 cdef class AngleAxisd(object):
   def __aaxisctor__(self, angle, Vector3d axis):
     self.impl = c_eigen.AngleAxisd(angle, axis.impl)
+  def __quatctor__(self, Quaterniond other):
+    self.impl = c_eigen.AngleAxisd(other.impl)
   def __cinit__(self, *args):
     if len(args) == 0:
       self.impl = c_eigen.AngleAxisd()
     elif len(args) == 2 and isinstance(args[1], Vector3d):
       self.__aaxisctor__(*args)
+    elif len(args) == 4 and isinstance(args[1], Quaterniond):
+      self.__quatctor__(*args)
     else:
       raise TypeError("Wrong arguments passed to AngleAxisd ctor")
   def matrix(self):

--- a/utils/quaternion.in.pyx
+++ b/utils/quaternion.in.pyx
@@ -52,6 +52,14 @@ cdef class Quaterniond(object):
     ret = Quaterniond()
     ret.impl = self.impl.conjugate()
     return ret
+  def __mul__(self, other):
+    if isinstance(self, Quaterniond):
+      if isinstance(other, Quaterniond):
+        return self.__mvec_mul(other)
+      else:
+        raise TypeError("Unsupported operands PTransformd and {0}".format(type(other)))
+    else:
+      return other.__mul__(self)
   def dot(self, Quaterniond other):
     return self.impl.dot(other.impl)
   def inverse(self):

--- a/utils/quaternion.in.pyx
+++ b/utils/quaternion.in.pyx
@@ -52,6 +52,8 @@ cdef class Quaterniond(object):
     ret = Quaterniond()
     ret.impl = self.impl.conjugate()
     return ret
+#  def __str__(self):
+#    return c_eigen_private.QtoString(self.impl)
   def __mul__(self, other):
     if isinstance(self, Quaterniond):
       if isinstance(other, Quaterniond):
@@ -97,6 +99,11 @@ cdef class Quaterniond(object):
   def Identity():
     ret = Quaterniond()
     ret.setIdentity()
+    return ret
+  @staticmethod
+  def UnitRandom():
+    ret = Quaterniond()
+    ret.UnitRandom
     return ret
 
 cdef Quaterniond QuaterniondFromC(const c_eigen.Quaterniond & arg):

--- a/utils/quaternion.in.pyx
+++ b/utils/quaternion.in.pyx
@@ -25,7 +25,7 @@ cdef class Quaterniond(object):
     elif len(args) == 4:
       self.impl = c_eigen.Quaterniond(args[0], args[1], args[2], args[3])
     else:
-      raise TypeError("Invalid arguments passed to MatrixXd ctor")
+      raise TypeError("Invalid argument ({}) passed to Quaterniond ctor".format(type(args[0])))
   def x(self):
     return self.impl.x()
   def y(self):
@@ -61,7 +61,7 @@ cdef class Quaterniond(object):
       if isinstance(other, Quaterniond):
         return self.__q_mul(other)
       else:
-        raise TypeError("Unsupported operands PTransformd and {0}".format(type(other)))
+        raise TypeError("Unsupported operands Quaterniond and {0}".format(type(other)))
     else:
       return other.__mul__(self)
   def dot(self, Quaterniond other):

--- a/utils/quaternion.in.pyx
+++ b/utils/quaternion.in.pyx
@@ -104,9 +104,7 @@ cdef class Quaterniond(object):
     return ret
   @staticmethod
   def UnitRandom():
-    ret = Quaterniond()
-    ret.UnitRandom
-    return ret
+    return QuaterniondFromC(c_eigen_private.EigenQuaternionUnitRandom())
 
 cdef Quaterniond QuaterniondFromC(const c_eigen.Quaterniond & arg):
   cdef Quaterniond ret = Quaterniond()

--- a/utils/quaternion.in.pyx
+++ b/utils/quaternion.in.pyx
@@ -54,10 +54,12 @@ cdef class Quaterniond(object):
     return ret
 #  def __str__(self):
 #    return c_eigen_private.QtoString(self.impl)
+  def __q_mul(self, Quaterniond other):
+    return QuaterniondFromC(self.impl*other.impl)
   def __mul__(self, other):
     if isinstance(self, Quaterniond):
       if isinstance(other, Quaterniond):
-        return self.__mvec_mul(other)
+        return self.__q_mul(other)
       else:
         raise TypeError("Unsupported operands PTransformd and {0}".format(type(other)))
     else:


### PR DESCRIPTION
I separated this change to make unit random quaternions work because `UnitRandom()` doesn't seem to work on every platform once it was specifically added in 4165a39. I was able to test and verify it works on my local machine. Perhaps this is an eigen version difference?

Merge https://github.com/jrl-umi3218/Eigen3ToPython/pull/15 before this.