### PR TITLE
[setup] Handle M1 arm64 arch and deprecation of pkg_resources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,8 @@ jobs:
       uses: jrl-umi3218/github-actions/build-cmake-project@master
       with:
         build-type: ${{ matrix.build-type }}
+      env:
+        ARCHFLAGS: "-arch arm64"
     - name: Slack Notification
       if: failure()
       uses: archive/github-actions-slack@master

--- a/setup.in.py
+++ b/setup.in.py
@@ -28,6 +28,7 @@ import sys
 
 win32_build = os.name == 'nt'
 
+
 from utils import generate_eigen_pyx
 
 this_path  = os.path.dirname(os.path.realpath(__file__))
@@ -46,6 +47,13 @@ def GenExtension(name):
   compile_args = ['-std=c++11']
   if win32_build:
       compile_args = ['-DWIN32']
+  elif sys.platform == 'darwin':
+    from platform import machine
+    osx_arch = machine()
+    print(f"OSX framework used, force to {osx_arch} only")
+    os.environ["ARCHFLAGS"] = os.environ.get("ARCHFLAGS", f"-arch {osx_arch}")
+    compile_args = ['-arch', osx_arch]
+
   return Extension(name, [ext_src], extra_compile_args = compile_args, include_dirs = include_dirs)
 
 extensions = [

--- a/setup.in.py
+++ b/setup.in.py
@@ -21,7 +21,6 @@ import sys
 
 win32_build = os.name == 'nt'
 
-
 from utils import generate_eigen_pyx
 
 this_path  = os.path.dirname(os.path.realpath(__file__))
@@ -38,7 +37,6 @@ def GenExtension(name):
   ext_src = pyx_src
   include_dirs = [os.path.join(os.getcwd(), "include"), "@EIGEN3_INCLUDE_DIR@", numpy.get_include()]
   compile_args = ['-std=c++11']
-  print(sys.platform)
   if win32_build:
       compile_args = ['-DWIN32']
   elif sys.platform == 'darwin':

--- a/setup.in.py
+++ b/setup.in.py
@@ -4,14 +4,9 @@
 
 from __future__ import print_function
 
-links = []
-requires = []
-requirements_file = "@CMAKE_CURRENT_SOURCE_DIR@/requirements.txt"
-
 try:
   from setuptools import setup
   from setuptools import Extension
-  from setuptools import find_packages
 except ImportError:
   from distutils.core import setup
   from distutils.extension import Extension
@@ -43,14 +38,14 @@ def GenExtension(name):
   ext_src = pyx_src
   include_dirs = [os.path.join(os.getcwd(), "include"), "@EIGEN3_INCLUDE_DIR@", numpy.get_include()]
   compile_args = ['-std=c++11']
+  print(sys.platform)
   if win32_build:
       compile_args = ['-DWIN32']
   elif sys.platform == 'darwin':
     from platform import machine
     osx_arch = machine()
-    print(f"OSX framework used, force to {osx_arch} only")
-    os.environ["ARCHFLAGS"] = os.environ.get("ARCHFLAGS", f"-arch {osx_arch}")
-    compile_args = ['-arch', osx_arch]
+    os.environ["ARCHFLAGS"] = "-arch " + osx_arch
+    compile_args += ["-arch", osx_arch]
 
   return Extension(name, [ext_src], extra_compile_args = compile_args, include_dirs = include_dirs)
 

--- a/setup.in.py
+++ b/setup.in.py
@@ -4,20 +4,14 @@
 
 from __future__ import print_function
 
+links = []
+requires = []
 requirements_file = "@CMAKE_CURRENT_SOURCE_DIR@/requirements.txt"
-with open(requirements_file) as fd:
-  for pkg in fd:
-    pkg = pkg.strip()
-    try:
-      import importlib
-      importlib.import_module(pkg)
-    except:
-      import pkg_resources
-      pkg_resources.require(pkg)
 
 try:
   from setuptools import setup
   from setuptools import Extension
+  from setuptools import find_packages
 except ImportError:
   from distutils.core import setup
   from distutils.extension import Extension
@@ -76,10 +70,17 @@ if cython_cxx_compiler_launcher:
 
 extensions = cythonize(extensions, cache = True)
 
+dependencies = [
+  "Cython>=0.2",
+  "coverage",
+  "numpy>=1.8.2",
+  "pytest"
+]
+
 setup(
     name = 'eigen',
     version='@PROJECT_VERSION@',
     ext_modules = extensions,
-    packages = packages,
-    package_data = { 'eigen': data }
+    package_data = { 'eigen': data },
+    install_requires=dependencies
 )

--- a/setup.in.py
+++ b/setup.in.py
@@ -4,12 +4,16 @@
 
 from __future__ import print_function
 
-import pkg_resources
 requirements_file = "@CMAKE_CURRENT_SOURCE_DIR@/requirements.txt"
 with open(requirements_file) as fd:
   for pkg in fd:
     pkg = pkg.strip()
-    pkg_resources.require(pkg)
+    try:
+      import importlib
+      importlib.import_module(pkg)
+    except:
+      import pkg_resources
+      pkg_resources.require(pkg)
 
 try:
   from setuptools import setup


### PR DESCRIPTION
The github runners have moved to using macos with an M1 architecture. The cython code needs to be compiled and run with the appropriate flags/env variables.