### PR TITLE
[python] Fix requirements

### DIFF
--- a/setup.in.py
+++ b/setup.in.py
@@ -4,6 +4,14 @@
 
 from __future__ import print_function
 
+
+import pkg_resources
+requirements_file = "@CMAKE_CURRENT_SOURCE_DIR@/requirements.txt"
+with open(requirements_file) as fd:
+  for pkg in fd:
+    pkg = pkg.strip()
+    pkg_resources.require(pkg)
+
 try:
   from setuptools import setup
   from setuptools import Extension
@@ -63,17 +71,10 @@ if cython_cxx_compiler_launcher:
 
 extensions = cythonize(extensions, cache = True)
 
-dependencies = [
-  "Cython>=0.2",
-  "coverage",
-  "numpy>=1.8.2",
-  "pytest"
-]
-
 setup(
     name = 'eigen',
     version='@PROJECT_VERSION@',
     ext_modules = extensions,
     package_data = { 'eigen': data },
-    install_requires=dependencies
+    packages = packages
 )


### PR DESCRIPTION
#31 attempted to remove the deprecated use of pkg_resources. However for some reason I could not yet figure out, it fails in some environments (but works in CI), despite declaring the exact same requirements. This will need to be revisited at a later date, for now restore the previous code and leave the fix for macos introduced in #31.